### PR TITLE
Allow colon in keys

### DIFF
--- a/segments/detect.go
+++ b/segments/detect.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	KeySegment = "^[a-zA-Z0-9_\\.-]+$"
+	KeySegment = "^[:a-zA-Z0-9_\\.-]+$"
 	// KeySearchSegment     = "^\\[\\.=[a-zA-Z][a-zA-Z0-9_-]*\\]$"
 	ExplicitIndexSegment = "^\\[[0-9]+\\]$"
 	ImplicitIndexSegment = "^[0-9]+$"

--- a/yamlpath_test.go
+++ b/yamlpath_test.go
@@ -27,6 +27,8 @@ users:
     roles:
       - Power Users
       - Editors
+:f:oo::
+  bar: baz
 `
 
 var tests = []struct { //nolint:gochecknoglobals
@@ -35,6 +37,7 @@ var tests = []struct { //nolint:gochecknoglobals
 	output   interface{}
 }{
 	{"DotNotation", "hash.child_attr.key", 5280},
+	{"DotNotation", ":f:oo:.bar", "baz"},
 	{"SlashNotation", "/hash/child_attr/key", 5280},
 	{"EscapedDotNotation", "hash.dotted\\.child.key", 42},
 	{"QuotedDotNotation", "hash.\"dotted.child\".key", 42},


### PR DESCRIPTION
Colons are often used in front of keys in YAML files in the Ruby world.
